### PR TITLE
Loosen Torch pinning (Fixes #4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -99,9 +99,9 @@ termcolor==2.4.0
 thop==0.1.1.post2209072238
 timm==1.0.9
 tomlkit==0.12.0
-torch==2.4.1
-torchaudio==2.4.0
-torchvision==0.19.1
+torch~=2.4.1
+torchaudio~=2.4.0
+torchvision~=0.19.1
 tqdm==4.66.5
 traitlets==5.14.3
 typer==0.12.5


### PR DESCRIPTION
Loosen torch pinning by using '~=' instead of '=='
```
torch~=2.4.1
torchaudio~=2.4.0
torchvision~=0.19.1
```

Fixes #4